### PR TITLE
Python 3 compatibility, with proper Python 2 backwards compatibility

### DIFF
--- a/example.py
+++ b/example.py
@@ -24,7 +24,19 @@ a = numpy.array( [[inf,2,11,10,8,7,6,5],
                   [10,11,12,10,9,12,inf,3],
                   [10,10,10,10,6,3,1,inf]] )
 
-answer = hungarian.lap(a)[0]
-print(answer)
-assert(numpy.array_equal([1, 2, 0, 4, 5, 3, 7, 6], answer))
+answers = hungarian.lap(a)
+print('For each row, matching column index:', answers[0])
+assert(numpy.array_equal([1, 2, 0, 4, 5, 3, 7, 6], answers[0]))
+points0 = list(zip(range(len(answers[0])), answers[0]))
+print('Matching pairs, sorted by row:', points0)
 
+print('For each column, matching row index:', answers[1])
+assert(numpy.array_equal([2, 0, 1, 5, 3, 4, 7, 6], answers[1]))
+points1 = list(zip(answers[1], range(len(answers[1]))))
+print('Matching pairs, sorted by col:', points1)
+
+sum0 = sum(a[range(len(answers[0])), answers[0]])
+sum1 = sum(a[answers[1], range(len(answers[1]))])
+print('Cost of match:', sum1)
+assert(sum0 == 17)
+assert(sum1 == 17)

--- a/example.py
+++ b/example.py
@@ -8,6 +8,7 @@ The cost matrix is based on Balas and Toth, 1985, Branch and bound
 # methods, in Lawler, E.L, et al., The TSP, John Wiley & Sons,
 Chischester, pp 361--401.
 """
+from __future__ import print_function
 
 import numpy
 import hungarian
@@ -23,5 +24,7 @@ a = numpy.array( [[inf,2,11,10,8,7,6,5],
                   [10,11,12,10,9,12,inf,3],
                   [10,10,10,10,6,3,1,inf]] )
 
-print  hungarian.lap(a)[0]
+answer = hungarian.lap(a)[0]
+print(answer)
+assert(numpy.array_equal([1, 2, 0, 4, 5, 3, 7, 6], answer))
 

--- a/hungarian.cpp
+++ b/hungarian.cpp
@@ -123,7 +123,13 @@ inithungarian(void)
 int main(int argc, char *argv[])
 {
   /* Pass argv[0] to the Python interpreter */
+#if PY_MAJOR_VERSION >= 3
   Py_SetProgramName((wchar_t*)argv[0]);
+
+#else
+  Py_SetProgramName(argv[0]);
+
+#endif
 
   /* Initialize the Python interpreter.  Required. */
   Py_Initialize();

--- a/hungarian.cpp
+++ b/hungarian.cpp
@@ -86,30 +86,56 @@ hungarian(PyObject *self, PyObject *args)
   return NULL;
 }
 
+static char module_docstring[] = "Solves the linear assignment problem using the Hungarian\nalgorithm.\n\nhungarian() takes a single argument - a square cost matrix - and returns a\ntuple of the form\n(row_assigns,col_assigns).";
+
 static PyMethodDef HungarianMethods[] = {
   {"lap",  hungarian, METH_VARARGS,
-   "Solves the linear assignment problem using the Hungarian\nalgorithm.\n\nhungarian() takes a single argument - a square cost matrix - and returns a\ntuple of the form\n(row_assigns,col_assigns)."},
+   module_docstring},
   {NULL, NULL, 0, NULL}        /* Sentinel (terminates structure) */
 };
 
+#if PY_MAJOR_VERSION >= 3
+
+static struct PyModuleDef Hungarian = 
+{
+    PyModuleDef_HEAD_INIT,
+    "hungarian",
+    module_docstring,
+    -1,
+    HungarianMethods
+};
+
+PyMODINIT_FUNC PyInit_hungarian(void) 
+{
+    import_array();
+    return PyModule_Create(&Hungarian);
+}
+
+#else
 PyMODINIT_FUNC
 inithungarian(void)
 {
   (void) Py_InitModule("hungarian", HungarianMethods);
   import_array();
 }
+#endif
 
-int
-main(int argc, char *argv[])
+int main(int argc, char *argv[])
 {
   /* Pass argv[0] to the Python interpreter */
-  Py_SetProgramName(argv[0]);
+  Py_SetProgramName((wchar_t*)argv[0]);
 
   /* Initialize the Python interpreter.  Required. */
   Py_Initialize();
 
   /* Add a static module */
+#if PY_MAJOR_VERSION >= 3
+  PyInit_hungarian();
+  
+#else
   inithungarian();
+
+#endif
 
   return 0;
 }


### PR DESCRIPTION
This should fix it so it works with Python 3 but retains its Python 2 functionality.  

This library still appears to be *significantly* faster than scipy.optimize.linear_sum_assignment(), and I need to call it thousands of times from code which only works in Python 3, so that was my impetus for doing this.

Thanks,
Chris